### PR TITLE
feat: search on enter in instance list

### DIFF
--- a/src/components/instances_page.rs
+++ b/src/components/instances_page.rs
@@ -54,6 +54,7 @@ impl SimpleComponent for InstancesPage {
                                 set_hexpand: true,
                                 set_tooltip_text: Some("Search"),
                                 set_buffer: &model.instances_search_buffer,
+                                connect_activate => InstancesPageInput::FetchInstances,
                             },
                             gtk::Button {
                                 set_label: "Filter",


### PR DESCRIPTION
Hi there,

As a user I find it a little bit more intuitive to be able to press [ENTER] when filtering an instance as opposed to moving my mouse and having to click on "Filter".

Hope this change makes sense.

Thanks
Lorenzo