### PR TITLE
Add infinite scroll behaviour

### DIFF
--- a/src/components/community_page.rs
+++ b/src/components/community_page.rs
@@ -54,6 +54,11 @@ impl SimpleComponent for CommunityPage {
     view! {
         gtk::ScrolledWindow {
             set_vexpand: false,
+            connect_edge_reached[sender] => move |_,pos| {
+                if pos == gtk::PositionType::Bottom {
+                    sender.input(CommunityInput::FetchPosts)
+                }
+            },
 
             gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,

--- a/src/components/posts_page.rs
+++ b/src/components/posts_page.rs
@@ -36,6 +36,14 @@ impl SimpleComponent for PostsPage {
     view! {
         gtk::ScrolledWindow {
             set_hexpand: true,
+            connect_edge_reached[sender] => move |_,pos| {
+                if pos == gtk::PositionType::Bottom {
+                    sender.input( 
+                        PostsPageInput::FetchPosts(
+                            model.posts_type, 
+                            model.posts_order, false))
+                }
+            },
 
             gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,


### PR DESCRIPTION
Good evening,

Since this is a common behaviour on many Social media app, i suggest to trigger post reload when main scrollable area reaches bottom corner instead of just calling it manually with a button.

Button can be kept as is to retrigger action in case of failed request.